### PR TITLE
Fixed main entry: __name__ == '__main__'

### DIFF
--- a/src/mewline/__main__.py
+++ b/src/mewline/__main__.py
@@ -58,7 +58,7 @@ def main():
     app.run()
 
 
-if __name__ == "main":
+if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Mewline: A minimalist status bar for meowrch."
     )


### PR DESCRIPTION
У меня после скачивания не генерировался конфиг и бинды, вылезало предупреждение что конфиг не найден, и будет создан дефолтный, но он так же не создавался и  mewline не запускался. 

Исправил ошибку запуска:
в `__main__.py` main не вызывался, потому что условие было `if __name__ == "main"` вместо `"__main__"`.

После исправления у меня локально все запустилось. Больше спасибо за проект!


