### PR TITLE
feat(dynamic island): introduced audio visualizer service and widget

### DIFF
--- a/src/mewline/constants.py
+++ b/src/mewline/constants.py
@@ -173,6 +173,7 @@ DEFAULT_CONFIG = {
                     "truncation": True,
                     "truncation_size": 30,
                     "default_album_logo": "https://sonos-partner-documentation.s3.amazonaws.com/ReadMe-External/content-service-features/add-images/add-album-art/SonosApp-DefaultArt-Alone.png",
+                    "visualizer_enabled": True,
                 },
             },
             "wallpapers": {

--- a/src/mewline/services/__init__.py
+++ b/src/mewline/services/__init__.py
@@ -1,6 +1,7 @@
 from fabric.audio import Audio
 from fabric.bluetooth import BluetoothClient
 
+from mewline.services.audio_visualizer import AudioVisualizerService
 from mewline.services.battery import BatteryService
 from mewline.services.brightness import BrightnessService
 from mewline.services.cache_notification import NotificationCacheService
@@ -8,6 +9,7 @@ from mewline.services.notifications import MyNotifications
 from mewline.services.privacy import PrivacyService
 
 audio_service = Audio()
+audio_visualizer_service = AudioVisualizerService(bar_count=6, fps=30)
 
 notification_service = MyNotifications()
 cache_notification_service = NotificationCacheService()

--- a/src/mewline/services/audio_visualizer.py
+++ b/src/mewline/services/audio_visualizer.py
@@ -1,0 +1,147 @@
+"""Service that provides audio level data for the waveform visualizer.
+
+Emits waveform bar levels at ~30 FPS. Uses mock/simulated data when playing;
+optionally scales by system volume if pulsectl is available.
+"""
+
+import math
+import random
+from collections.abc import Callable
+from gi.repository import GLib
+
+try:
+    import pulsectl
+except ImportError:
+    pulsectl = None
+
+from loguru import logger
+
+
+class AudioVisualizerService:
+    """Emits waveform level data for visualization.
+
+    When started, runs a timer that pushes lists of float levels (0.0–1.0)
+    for each bar. Uses smoothed mock data; can optionally scale by PulseAudio
+    volume if pulsectl is available.
+    """
+
+    def __init__(
+        self,
+        bar_count: int = 6,
+        fps: int = 50,
+        smoothing: float = 0.7,
+        on_levels: Callable[[list[float]], None] | None = None,
+    ):
+        self._bar_count = bar_count
+        self._interval_ms = max(16, int(1000 / fps))
+        self._smoothing = max(0.01, min(1.0, smoothing))
+        self._time = 0.0
+        self._levels: list[float] = [0.0] * bar_count
+        self._targets: list[float] = [0.0] * bar_count
+        self._velocities: list[float] = [0.0] * bar_count
+        self._source_id: int | None = None
+        self._callbacks: list[Callable[[list[float]], None]] = []
+        if on_levels is not None:
+            self._callbacks.append(on_levels)
+        self._pulse = None
+        if pulsectl is not None:
+            try:
+                self._pulse = pulsectl.Pulse("billpanel-visualizer")
+            except Exception as e:
+                logger.debug(f"[AudioVisualizer] Pulse connection failed: {e}")
+
+    @property
+    def bar_count(self) -> int:
+        return self._bar_count
+
+    def _get_volume_scale(self) -> float:
+        """Return 0.0–1.0 scale from default sink volume if Pulse is available."""
+        if self._pulse is None:
+            return 1.0
+        try:
+            for sink in self._pulse.sink_list():
+                vol = getattr(sink, "volume", None)
+                if vol is None:
+                    continue
+                values = getattr(vol, "values", None) or getattr(vol, "value_list", None)
+                if values:
+                    total = sum(values) / len(values)
+                    return min(1.0, total / 65536.0)
+            return 1.0
+        except Exception:
+            return 1.0
+
+    def _tick(self) -> bool:
+        """Advance waveform with bouncy spring-like animation."""
+        self._time += self._interval_ms / 1000.0
+        scale = self._get_volume_scale()
+
+        stiffness = 0.35
+        damping = 0.55
+
+        for i in range(self._bar_count):
+            phase = self._time * 4.0 + i * 1.2
+            wave = 0.25 + 0.65 * abs(math.sin(phase))
+            jitter = 0.35 * (random.random() - 0.5)
+            if random.random() < 0.12:
+                jitter += 0.3 * (random.random() - 0.3)
+            target = scale * max(0.0, min(1.0, wave + jitter))
+            self._targets[i] = target
+
+            diff = self._targets[i] - self._levels[i]
+            self._velocities[i] += diff * stiffness
+            self._velocities[i] *= damping
+            self._levels[i] += self._velocities[i]
+            self._levels[i] = max(0.0, min(1.0, self._levels[i]))
+
+        self.emit_levels(self._levels)
+        return True
+
+    def set_callback(self, callback: Callable[[list[float]], None] | None) -> None:
+        """Add or remove callback invoked with list of bar levels (0.0–1.0) each frame."""
+        if callback is None:
+            return
+        if callback not in self._callbacks:
+            self._callbacks.append(callback)
+
+    def remove_callback(self, callback: Callable[[list[float]], None] | None) -> None:
+        """Remove a previously registered callback."""
+        if callback is not None and callback in self._callbacks:
+            self._callbacks.remove(callback)
+
+    def emit_levels(self, levels: list[float]) -> None:
+        """Notify all registered callbacks with current levels."""
+        for callback in self._callbacks:
+            try:
+                callback(levels)
+            except Exception as e:
+                logger.debug(f"[AudioVisualizer] Callback error: {e}")
+
+    def start(self) -> None:
+        """Start emitting level updates."""
+        if self._source_id is not None:
+            return
+        self._source_id = GLib.timeout_add(
+            self._interval_ms,
+            self._tick,
+            priority=GLib.PRIORITY_DEFAULT,
+        )
+
+    def stop(self) -> None:
+        """Stop emitting level updates."""
+        if self._source_id is not None:
+            GLib.source_remove(self._source_id)
+            self._source_id = None
+        self._levels = [0.0] * self._bar_count
+        self._targets = [0.0] * self._bar_count
+        self._velocities = [0.0] * self._bar_count
+
+    def close(self) -> None:
+        """Release Pulse connection if any."""
+        self.stop()
+        if self._pulse is not None:
+            try:
+                self._pulse.close()
+            except Exception:
+                pass
+            self._pulse = None

--- a/src/mewline/styles/dynamic_island/island.scss
+++ b/src/mewline/styles/dynamic_island/island.scss
@@ -147,6 +147,12 @@
   font-weight: bold;
 }
 
+#di-audio-visualizer {
+  min-width: 36px;
+  min-height: 20px;
+  color: theme.$accent-color;
+}
+
 #dynamic-island-corner-left {
   margin-left: -16px;
 }

--- a/src/mewline/utils/config_structure.py
+++ b/src/mewline/utils/config_structure.py
@@ -162,6 +162,7 @@ class MusicModule(BaseModel):
     truncation: bool
     truncation_size: int
     default_album_logo: str
+    visualizer_enabled: bool
 
 
 class Compact(BaseModel):

--- a/src/mewline/widgets/audio_visualizer.py
+++ b/src/mewline/widgets/audio_visualizer.py
@@ -1,0 +1,112 @@
+"""Waveform audio visualizer widget for the Dynamic Island."""
+
+import math
+
+import cairo
+from gi.repository import Gtk
+
+
+class AudioVisualizerWidget(Gtk.DrawingArea):
+    """Compact icon-like waveform visualizer with pill-shaped bars.
+
+    Has static padding bars on left/right edges; inner bars are animated.
+    """
+
+    def __init__(
+        self,
+        bar_count: int = 6,
+        animated_bars: int = 4,
+        min_width: int = 36,
+        min_height: int = 20,
+        static_level: float = 0.25,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self._bar_count = bar_count
+        self._animated_bars = min(animated_bars, bar_count)
+        self._static_level = static_level
+        self._levels: list[float] = [0.0] * animated_bars
+        self.set_size_request(min_width, min_height)
+        self.set_name("di-audio-visualizer")
+        self.connect("draw", self._on_draw)
+
+    def set_levels(self, levels: list[float]) -> None:
+        """Update animated bar levels (0.0-1.0). Triggers redraw."""
+        n = min(len(levels), self._animated_bars)
+        for i in range(n):
+            self._levels[i] = max(0.0, min(1.0, float(levels[i])))
+        for i in range(n, self._animated_bars):
+            self._levels[i] = 0.0
+        self.queue_draw()
+
+    def _draw_pill_bar(
+        self,
+        cr: cairo.Context,
+        x: float,
+        y_top: float,
+        bar_width: float,
+        bar_h: float,
+    ) -> None:
+        """Draw a single vertical pill/capsule (rounded top and bottom)."""
+        if bar_h < 1:
+            return
+        radius = min(bar_width, bar_h) / 2
+        if radius <= 0:
+            return
+        cx = x + bar_width / 2
+        if bar_h <= bar_width:
+            cr.arc(cx, y_top + bar_h / 2, radius, 0, 2 * math.pi)
+            cr.fill()
+            return
+        # Top cap (half circle)
+        cr.arc(cx, y_top + radius, radius, math.pi, 0)
+        # Right edge
+        cr.line_to(cx + radius, y_top + bar_h - radius)
+        # Bottom cap
+        cr.arc(cx, y_top + bar_h - radius, radius, 0, math.pi)
+        # Left edge
+        cr.line_to(cx - radius, y_top + radius)
+        cr.close_path()
+        cr.fill()
+
+    def _on_draw(self, widget, cr: cairo.Context) -> bool:
+        width = widget.get_allocated_width()
+        height = widget.get_allocated_height()
+        if width <= 0 or height <= 0:
+            return False
+
+        style = widget.get_style_context()
+        color = style.get_color(Gtk.StateFlags.NORMAL)
+        if color:
+            r, g, b, a = color.red, color.green, color.blue, color.alpha
+            cr.set_source_rgba(r, g, b, a)
+        else:
+            cr.set_source_rgba(0.7, 0.7, 0.7, 0.9)
+
+        padding = 2
+        center_y = height / 2
+        gap = 2
+        bar_width = max(2, (width - 2 * padding - (self._bar_count - 1) * gap) / self._bar_count)
+        max_h = (height - 2 * padding) / 2
+
+        total_bars_width = self._bar_count * bar_width + (self._bar_count - 1) * gap
+        start_x = (width - total_bars_width) / 2
+
+        padding_bars_left = (self._bar_count - self._animated_bars) // 2
+        padding_bars_right = self._bar_count - self._animated_bars - padding_bars_left
+
+        for i in range(self._bar_count):
+            if i < padding_bars_left:
+                level = self._static_level
+            elif i >= self._bar_count - padding_bars_right:
+                level = self._static_level
+            else:
+                anim_idx = i - padding_bars_left
+                level = self._levels[anim_idx] if anim_idx < len(self._levels) else 0.0
+
+            bar_h = max(2, level * max_h)
+            x = start_x + i * (bar_width + gap)
+            y_top = center_y - bar_h / 2
+            cr.new_path()
+            self._draw_pill_bar(cr, x, y_top, bar_width, bar_h)
+        return False

--- a/src/mewline/widgets/dynamic_island/compact.py
+++ b/src/mewline/widgets/dynamic_island/compact.py
@@ -16,10 +16,12 @@ from loguru import logger
 
 from mewline.config import cfg
 from mewline.constants import WINDOW_TITLE_MAP
+from mewline.services import audio_visualizer_service
 from mewline.services.mpris import MprisPlayer
 from mewline.services.mpris import MprisPlayerManager
 from mewline.utils.widget_utils import setup_cursor_hover
 from mewline.utils.widget_utils import text_icon
+from mewline.widgets.audio_visualizer import AudioVisualizerWidget
 from mewline.widgets.dynamic_island.base import BaseDiWidget
 
 if TYPE_CHECKING:
@@ -47,7 +49,27 @@ class Compact(BaseDiWidget, CenterBox):
 
         self.cover = Box(style_classes="cover", visible=False)
         self.music_label = Label(style_classes="panel-text", visible=False)
-        self.music_box = Box(children=[self.cover, self.music_label])
+        viz_enabled = self.config.music.visualizer_enabled
+        self.visualizer = (
+            AudioVisualizerWidget(
+                bar_count=6,
+                animated_bars=4,
+                min_width=28,
+                min_height=20,
+                static_level=0.25,
+            )
+            if viz_enabled
+            else None
+        )
+        if self.visualizer is not None:
+            self.visualizer.set_margin_start(4)
+            self.visualizer.hide()
+        music_children: list = [self.cover, self.music_label]
+        if self.visualizer is not None:
+            music_children.append(self.visualizer)
+        self.music_box = Box(
+            orientation="h", spacing=4, children=music_children
+        )
 
         # Create adaptive active window widget
         self.window_title = self._create_active_window_widget()
@@ -274,6 +296,11 @@ class Compact(BaseDiWidget, CenterBox):
             )
             self._music_last_art_url = art_url
 
+        if self.visualizer is not None:
+            audio_visualizer_service.set_callback(self.visualizer.set_levels)
+            audio_visualizer_service.start()
+            self.visualizer.show()
+
         self.main_container.children = [self.music_box]
         self.cover.show()
         self.music_label.show()
@@ -487,6 +514,11 @@ class Compact(BaseDiWidget, CenterBox):
         self.cover.set_style(
             f"background-image: url('{art_url}'); background-size: cover;"
         )
+        
+        if self.visualizer is not None:
+            audio_visualizer_service.set_callback(self.visualizer.set_levels)
+            audio_visualizer_service.start()
+            self.visualizer.show()
 
         # Обновление контейнера
         self.main_container.children = [self.music_box]
@@ -495,6 +527,12 @@ class Compact(BaseDiWidget, CenterBox):
 
     def _show_window_title(self):
         """Show window title with icon."""
+        if self.visualizer is not None:
+            audio_visualizer_service.remove_callback(self.visualizer.set_levels)
+            # Only stop if no callbacks remain
+            if not audio_visualizer_service._callbacks:
+                audio_visualizer_service.stop()
+            self.visualizer.hide()
         # Ensure icon enablement applied before showing row
         self._apply_icon_enablement()
         self.main_container.children = [self.window_row]


### PR DESCRIPTION
This PR merges the `feature/audio-visualizer` work into `merge/audio-visualizer` (branched off `main`).

Changes include:

- **Audio visualizer service**
  - Adds `AudioVisualizerService` that generates smooth, animated waveform levels.
  - Supports multiple callbacks so several widgets (multi-monitor) can visualize the same audio stream.
  - Optionally scales levels by PulseAudio volume when available.

- **Dynamic Island integration**
  - Integrates `AudioVisualizerWidget` into the compact Dynamic Island music view.
  - Starts the visualizer when music is playing and hides it when playback stops.
  - Ensures all Dynamic Island instances (multi-monitor) receive level updates without interfering with each other.

- **UI widget**
  - Adds a compact pill-bar `AudioVisualizerWidget` for rendering the animated waveform.
  - Respects theming and layout constraints used by the Dynamic Island compact view.

<div align="center">
  <img src="https://github.com/user-attachments/assets/9f323a0f-af23-4ad7-9e52-13eed8f00dbf" alt="preview" />
  <img src="https://github.com/user-attachments/assets/9f323a0f-af23-4ad7-9e52-13eed8f00dbf" alt="preview" />
</div>